### PR TITLE
Store Monaco editor UI state when switching code to improve simulator UX

### DIFF
--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -36,10 +36,27 @@ class Editor extends Component {
 
     componentDidUpdate(prevProps) {
         if ((prevProps.data !== this.props.data || prevProps.language !== this.props.language) && this.editor) {
+            // store editor focus state
+            const hasFocus = this.editor.isFocused();
+            // save editor UI state
+            const currentEditorState = this.editor.saveViewState();
+            sessionStorage.setItem(prevProps.uniqueId, JSON.stringify(currentEditorState));
+            // reconfigure editor
             this.editor.setValue(this.props.data);
             this.editor.updateOptions({
                 language: this.props.language,
             });
+            // restore editor UI state for current model (if already saved)
+            const oldEditorState = sessionStorage.getItem(this.props.uniqueId);
+            if(oldEditorState) {
+                this.editor.restoreViewState(JSON.parse(oldEditorState));
+            } else {
+                this.editor.setScrollPosition({scrollTop: 0});
+            }
+            // restore focus
+            if(hasFocus) {
+                this.editor.focus();
+            }
         }
     }
 

--- a/src/containers/editor.js
+++ b/src/containers/editor.js
@@ -6,6 +6,7 @@ import * as GUIDE from '../constants/guide';
 const mapStateToProps = (state) => ({
     data: state.project.get('codeInEditor'),
     language: state.project.get('codeLanguage'),
+    uniqueId: state.project.get('codeUniqueId'),
     highlight: state.main.get('guideId') === GUIDE.EDITOR,
 });
 

--- a/src/lib/projectFactory.js
+++ b/src/lib/projectFactory.js
@@ -1,6 +1,8 @@
 import { Map } from 'immutable';
 import * as CONSTANTS from '../constants/localStorageKeys';
 
+const createHash = () => Math.random().toString(36).substring(7);
+
 export const getAllProjects = () => {
 	return Map({
 		GetStarted: Map({
@@ -11,31 +13,37 @@ export const getAllProjects = () => {
             }),
 			files: Map({
 				"GetStarted.ino": Map({
+					id: createHash(),
 					type: "file",
 					format: "cpp",
 					data: require('../data/GetStarted/GetStarted.ino'),
 				}),
 				"iothub_client_sample_mqtt.h": Map({
+					id: createHash(),
 					type: "file",
 					format: "cpp",
 					data: require('../data/GetStarted/iothub_client_sample_mqtt.h'),
 				}),
 				"iothub_client_sample_mqtt.cpp": Map({
+					id: createHash(),
 					type: "file",
 					format: "cpp",
 					data: require('../data/GetStarted/iothub_client_sample_mqtt.cpp'),
 				}),
 				"utility.h": Map({
+					id: createHash(),
 					type: "file",
 					format: "cpp",
 					data: require('../data/GetStarted/utility.h'),
 				}),
 				"utility.cpp": Map({
+					id: createHash(),
 					type: "file",
 					format: "cpp",
 					data: require('../data/GetStarted/utility.cpp'),
 				}),
 				"config.h": Map({
+					id: createHash(),
 					type: "file",
 					format: "cpp",
 					data: require('../data/GetStarted/config.h'),
@@ -55,16 +63,19 @@ export const getAllProjects = () => {
 					type: "directory",
 					data: Map({
 						"function.json": Map({
+							id: createHash(),
 							type: "file",
 							format: "json",
 							data: require('../data/ShakeShake/azureFunction/function.json'),
 						}),
 						"run.csx": Map({
+							id: createHash(),
 							type: "file",
 							format: "csharp",
 							data: require('../data/ShakeShake/azureFunction/run.csx'),
 						}),
 						"project.json": Map({
+							id: createHash(),
 							type: "file",
 							format: "json",
 							data: require('../data/ShakeShake/azureFunction/project.json'),
@@ -72,16 +83,19 @@ export const getAllProjects = () => {
 					})
 				}),
 				"ShakeShake.ino": Map({
+					id: createHash(),
 					type: "file",
 					format: "cpp",
                     data: localStorage.getItem(CONSTANTS.SHAKESHAKE_TOPIC) ? require('../data/ShakeShake/ShakeShake.ino').replace(/("{\\"topic\\":\\")[^\\]*(\\"}";)/, '$1' + localStorage.getItem(CONSTANTS.SHAKESHAKE_TOPIC) + '$2') : require('../data/ShakeShake/ShakeShake.ino'),
 				}),
 				"ShakeUI.h": Map({
+					id: createHash(),
 					type: "file",
 					format: "cpp",
 					data: require('../data/ShakeShake/ShakeUI.h'),
 				}),
 				"ShakeUI.cpp": Map({
+					id: createHash(),
 					type: "file",
 					format: "cpp",
 					data: require('../data/ShakeShake/ShakeUI.cpp'),

--- a/src/reducers/project.js
+++ b/src/reducers/project.js
@@ -11,7 +11,7 @@ const getCodeInFirstFile = (project) => {
     // eslint-disable-next-line no-unused-vars
     for (let [k, v] of project.get('files')) {
         if (v.get('type') === 'file') {
-            return [v.get('data'), v.get('format')];
+            return [v.get('data'), v.get('format'), v.get('id')];
         }
     }
 };
@@ -20,10 +20,12 @@ const allProjects = getAllProjects();
 const initProject = allProjects.get('ShakeShake');
 let codeInEditor;
 let codeLanguage;
-[codeInEditor, codeLanguage] = getCodeInFirstFile(initProject);
+let codeUniqueId;
+[codeInEditor, codeLanguage, codeUniqueId] = getCodeInFirstFile(initProject);
 const initialState = Map({
     codeInEditor,
     codeLanguage,
+    codeUniqueId,
     currentProject: initProject,
     projects: allProjects,
 });
@@ -34,6 +36,7 @@ const project = (state = initialState, action) => {
         return state.merge(Map({
             codeInEditor: file.get('data'),
             codeLanguage: file.get('format'),
+            codeUniqueId: file.get('id'),
         }));
     } else if (action.type === SELECT_PROJECT) {
         let currentProject = state.getIn(['projects', action.data]);
@@ -43,11 +46,13 @@ const project = (state = initialState, action) => {
         }
         let codeInEditor;
         let codeLanguage;
-        [codeInEditor, codeLanguage] = getCodeInFirstFile(currentProject);
+        let codeUniqueId;
+        [codeInEditor, codeLanguage, codeUniqueId] = getCodeInFirstFile(currentProject);
         return state.merge(Map({
             currentProject,
             codeInEditor,
             codeLanguage,
+            codeUniqueId,
         }));
     } else if (action.type === SET_PROJECT_CONFIG) {
         let currentProject = state.get('currentProject');


### PR DESCRIPTION
This commit improves UX of the simulator code editor by saving editor
state into the session storage. This allows to restore:
- scroll position
- code selection
- folding
when the user switches back and forth between project files.
The model for project files has been changed to generate short unique
identifier used later in editor component to hash a session storage information
in order to save/restore editor UI state.

Thanks!